### PR TITLE
trustAllCertificates parameter

### DIFF
--- a/www/bridge.open.js
+++ b/www/bridge.open.js
@@ -13,18 +13,19 @@ var exec = require('cordova/exec');
  * @param {String} args File URI
  * @param {Function} success Success callback
  * @param {Function} error Failure callback
+ * @param {Boolean} trustAllCertificates Trusts any certificate when the connection is done over HTTPS - avoid this in production -
  */
-exports.open = function(uri, success, error) {
-  if (!uri || arguments.length === 0) { return false; }
+exports.open = function (uri, success, error, trustAllCertificates) {
+    if (!uri || arguments.length === 0) { return false; }
 
-  uri = encodeURI(uri);
+    uri = encodeURI(uri);
 
-  if (uri.match('http')) {
-    downloadAndOpen(uri, success, error);
-  } else {
-    exec(onSuccess.bind(this, uri, success),
-         onError.bind(this, error), 'Open', 'open', [uri]);
-  }
+    if (uri.match('http')) {
+        downloadAndOpen(uri, success, error, trustAllCertificates);
+    } else {
+        exec(onSuccess.bind(this, uri, success),
+             onError.bind(this, error), 'Open', 'open', [uri]);
+    }
 };
 
 /**
@@ -33,24 +34,30 @@ exports.open = function(uri, success, error) {
  * @param {String} url File URI
  * @param {Function} success Success callback
  * @param {Function} error Failure callback
+ * @param {Boolean} trustAllCertificates Trusts any certificate when the connection is done over HTTPS - avoid this in production -
  */
-function downloadAndOpen(url, success, error) {
-  var ft = new FileTransfer();
-  var ios = cordova.file.cacheDirectory;
-  var ext = cordova.file.externalCacheDirectory;
-  var dir = (ext) ?  ext : ios;
-  var name = url.substring(url.lastIndexOf('/') + 1);
-  var path = dir + name;
+function downloadAndOpen(url, success, error, trustAllCertificates) {
+    var ft = new FileTransfer();
+    var ios = cordova.file.cacheDirectory;
+    var ext = cordova.file.externalCacheDirectory;
+    var dir = (ext) ? ext : ios;
+    var name = url.substring(url.lastIndexOf('/') + 1);
+    var path = dir + name;
 
-  ft.download(url, path,
-      function done(entry) {
-        var file = entry.toURL();
-        exec(onSuccess.bind(this, file, success),
-             onError.bind(this, error), 'Open', 'open', [file]);
-      },
-      onError.bind(this, error),
-      false
-  );
+    if (typeof trustAllCertificates != "boolean") {
+        // Defaults to false
+        trustAllCertificates = false;
+    }
+
+    ft.download(url, path,
+        function done(entry) {
+            var file = entry.toURL();
+            exec(onSuccess.bind(this, file, success),
+                 onError.bind(this, error), 'Open', 'open', [file]);
+        },
+        onError.bind(this, error),
+        trustAllCertificates
+    );
 }
 
 /**
@@ -61,11 +68,11 @@ function downloadAndOpen(url, success, error) {
  * @return {String} File URI
  */
 function onSuccess(path, callback) {
-  fire('success', path);
-  if (typeof callback === 'function') {
-    callback(path);
-  }
-  return path;
+    fire('success', path);
+    if (typeof callback === 'function') {
+        callback(path);
+    }
+    return path;
 }
 
 /**
@@ -75,12 +82,12 @@ function onSuccess(path, callback) {
  * @return {Number} Error Code
  */
 function onError(callback) {
-  var code = (arguments.length > 1) ? arguments[1] : 0;
-  fire('error', code);
-  if (typeof callback === 'function') {
-    callback(code);
-  }
-  return code;
+    var code = (arguments.length > 1) ? arguments[1] : 0;
+    fire('error', code);
+    if (typeof callback === 'function') {
+        callback(code);
+    }
+    return code;
 }
 
 /**
@@ -90,14 +97,14 @@ function onError(callback) {
  * @param {String} data Success or error data
  */
 function fire(event, data) {
-  var channel = require('cordova/channel');
-  var cordova = require('cordova');
-  var payload = {};
+    var channel = require('cordova/channel');
+    var cordova = require('cordova');
+    var payload = {};
 
-  channel.onCordovaReady.subscribe(function() {
-    var name = 'open.' + event;
-    var prop = (event === 'error') ? event : 'data';
-    payload[prop] = data;
-    cordova.fireDocumentEvent(name, payload);
-  });
+    channel.onCordovaReady.subscribe(function () {
+        var name = 'open.' + event;
+        var prop = (event === 'error') ? event : 'data';
+        payload[prop] = data;
+        cordova.fireDocumentEvent(name, payload);
+    });
 }


### PR DESCRIPTION
Since Android rejects self-signed certificates for SSL connections, I required this new argument so I can acept any certificate during development and set it to `true`.

It defaults to `false` so previous code using this plugin will work seamlessly.