### PR TITLE
Avoid double-encoding remote URLs

### DIFF
--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -20,11 +20,10 @@ var exec = require('cordova/exec');
 exports.open = function(uri, success, error, trustAllCertificates) {
   if (!uri || arguments.length === 0) { return false; }
 
-  uri = encodeURI(uri);
-
   if (uri.match('http')) {
     downloadAndOpen(uri, success, error, trustAllCertificates);
   } else {
+    uri = encodeURI(uri);
     exec(onSuccess.bind(this, uri, success),
          onError.bind(this, error), 'Open', 'open', [uri]);
   }


### PR DESCRIPTION
Remote URLs with spaces are currently broken since they get encoded twice, first by the javascript in cordova-open and then by cordova-plugin-file-transfer. Every space becomes %20 and then %2520.