### PR TITLE
Manipulation to UI should be done on main thread

### DIFF
--- a/src/ios/Open.m
+++ b/src/ios/Open.m
@@ -30,7 +30,9 @@
           
         [previewCtrl.navigationItem setRightBarButtonItem:nil];
           
-        [self.viewController presentViewController:previewCtrl animated:YES completion:nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [self.viewController presentViewController:previewCtrl animated:YES completion:nil];
+        });
 
         NSLog(@"cordova.disusered.open - Success!");
         commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK


### PR DESCRIPTION
Any direct manipulation to UI should be done on main thread & not from background thread otherwise this will make the app to crash on iOS10 when you try to open the file