### PR TITLE
Feature/resume on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cordova.plugins.disusered.open(file, success, error, trustAllCertificates)
 * __trustAllCertificates:__ Optional, trusts any certificate when the connection is done over HTTPS.
 
 #### Events:
-* __pause:__ Opening files emits Cordova's pause event
+* __pause:__ Opening files emits Cordova's pause event (Android only)
 * __resume:__ Closing the file emits Cordova's resume event
 * __open.success:__ File is found and can be opened
 * __open.error:__ File not found, or no file handler is installed

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cordova.plugins.disusered.open(file, success, error, trustAllCertificates)
 
 #### Events:
 * __pause:__ Opening files emits Cordova's pause event (Android only)
-* __resume:__ Closing the file emits Cordova's resume event
+* __resume:__ Closing the file emits Cordova's resume event (new: also triggered under iOS now)
 * __open.success:__ File is found and can be opened
 * __open.error:__ File not found, or no file handler is installed
 

--- a/src/ios/Open.h
+++ b/src/ios/Open.h
@@ -9,5 +9,6 @@
 
 @property(strong, nonatomic) NSURL *fileUrl;
 @property(readonly) NSURL *previewItemURL;
+@property (nonatomic, copy) NSString* callbackId;
 
 @end

--- a/src/ios/Open.m
+++ b/src/ios/Open.m
@@ -8,6 +8,7 @@
  *  @param command An array of arguments passed from javascript
  */
 - (void)open:(CDVInvokedUrlCommand *)command {
+  self.callbackId = command.callbackId;
 
   // Check command.arguments here.
   [self.commandDelegate runInBackground:^{
@@ -37,6 +38,7 @@
         NSLog(@"cordova.disusered.open - Success!");
         commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                           messageAsString:@""];
+        [commandResult setKeepCallback:[NSNumber numberWithBool:YES]];
 
       } else {
         NSLog(@"cordova.disusered.open - Invalid file URL");
@@ -62,6 +64,13 @@
 - (id<QLPreviewItem>)previewController:(QLPreviewController *)controller
                     previewItemAtIndex:(NSInteger)index {
   return self;
+}
+
+- (void)previewControllerDidDismiss:(QLPreviewController *)controller {
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"resume"];
+    [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    self.callbackId = nil;
 }
 
 #pragma - QLPreviewItem Protocol

--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -71,7 +71,7 @@ function downloadAndOpen(url, success, error, trustAllCertificates) {
  */
 function onSuccess(path, callback, type) {
   if(type !== 'resume') {
-      fire('success' , path);
+      fire('open.success' , path);
       if (typeof callback === 'function') {
         callback(path);
       }
@@ -89,7 +89,7 @@ function onSuccess(path, callback, type) {
  */
 function onError(callback) {
   var code = (arguments.length > 1) ? arguments[1] : 0;
-  fire('error', code);
+  fire('open.error', code);
   if (typeof callback === 'function') {
     callback(code);
   }
@@ -109,9 +109,8 @@ function fire(event, data) {
   var payload = {};
 
   channel.onCordovaReady.subscribe(function() {
-    var name = 'open.' + event;
     var prop = (event === 'error') ? event : 'data';
     payload[prop] = data;
-    cordova.fireDocumentEvent(name, payload);
+    cordova.fireDocumentEvent(event, payload);
   });
 }

--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -69,10 +69,14 @@ function downloadAndOpen(url, success, error, trustAllCertificates) {
  * @param {Function} callback Callback
  * @returns {String} File URI
  */
-function onSuccess(path, callback) {
-  fire('success', path);
-  if (typeof callback === 'function') {
-    callback(path);
+function onSuccess(path, callback, type) {
+  if(type !== 'resume') {
+      fire('success' , path);
+      if (typeof callback === 'function') {
+        callback(path);
+      }
+  } else {
+      fire('resume' , path);
   }
   return path;
 }


### PR DESCRIPTION
Hi.

I had the need to get notice when the user closes the document. Android fires the resume event but iOS does not, so I added this behavior.
Additionally, I updated the README.md to make clear that the pause event is still only fired under Android and I made a note that the resume event is now supported under iOS as well.

regards
Frank