### PR TITLE
Get mime type from lower cased extension

### DIFF
--- a/src/android/Open.java
+++ b/src/android/Open.java
@@ -41,7 +41,7 @@ public class Open extends CordovaPlugin {
     String extension = MimeTypeMap.getFileExtensionFromUrl(path);
     if (extension != null) {
       MimeTypeMap mime = MimeTypeMap.getSingleton();
-      mimeType = mime.getMimeTypeFromExtension(extension);
+      mimeType = mime.getMimeTypeFromExtension(extension.toLowerCase());
     }
 
     System.out.println("Mime type: " + mimeType);


### PR DESCRIPTION
Opening files with upper-case extensions (e.g. `file.JPG`) causes `android.webkit.MimeTypeMap`'s lookup to fail, resulting in files being opened with the wrong app (which usually results in them being unopenable). This normalizes the extension to lower case.