### PR TITLE
Add progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,38 @@ function error(code) {
   }
 }
 
-open('file:/storage/sdcard/DCIM/Camera/1404177327783.jpg', success, error);
+function progress(progressEvent) {
+  if (progressEvent.lengthComputable) {
+    var perc = Math.floor(progressEvent.loaded / progressEvent.total * 100);
+    // update UI with status, for example:
+    // statusDom.innerHTML = perc + "% loaded...";
+  } else {
+    // download does not offer a length... just show dots
+    /*
+       if(statusDom.innerHTML == "") {
+       statusDom.innerHTML = "Loading";
+       } else {
+       statusDom.innerHTML += ".";
+       }
+     */
+  }
+};
+
+open('file:/storage/sdcard/DCIM/Camera/1404177327783.jpg', success, error, progress);
 ```
 
 ## API
 The plugin exposes the following methods:
 
 ```javascript
-cordova.plugins.disusered.open(file, success, error, trustAllCertificates)
+cordova.plugins.disusered.open(file, success, error, progress, trustAllCertificates)
 ```
 
 #### Parameters:
 * __file:__ A string representing a URI
 * __success:__ Optional success callback
 * __error:__ Optional error callback
+* __progress:__ Optional progress callback
 * __trustAllCertificates:__ Optional, trusts any certificate when the connection is done over HTTPS.
 
 #### Events:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/disusered/cordova-open",
   "devDependencies": {
     "eslint": "^0.24.1",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-eslint": "^0.15.0"
   }
 }

--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -73,16 +73,17 @@ function downloadAndOpen(url, success, error, progress, trustAllCertificates) {
  *
  * @param {String} path File URI
  * @param {Function} callback Callback
+ * @param {type} type of success event
  * @returns {String} File URI
  */
 function onSuccess(path, callback, type) {
   if(type !== 'resume') {
-      fire('open.success' , path);
+      fire('open.success', path);
       if (typeof callback === 'function') {
         callback(path);
       }
   } else {
-      fire('resume' , path);
+      fire('resume', path);
   }
   return path;
 }

--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -14,14 +14,15 @@ var exec = require('cordova/exec');
  * @param {String} uri File URI
  * @param {Function} success Success callback
  * @param {Function} error Failure callback
+ * @param {Function} progress Callback for download progress reporting
  * @param {Boolean} trustAllCertificates Trusts any certificate when the connection is done over HTTPS.
  * @returns {void}
  */
-exports.open = function(uri, success, error, trustAllCertificates) {
+exports.open = function(uri, success, error, progress, trustAllCertificates) {
   if (!uri || arguments.length === 0) { return false; }
 
   if (uri.match('http')) {
-    downloadAndOpen(uri, success, error, trustAllCertificates);
+    downloadAndOpen(uri, success, error, progress, trustAllCertificates);
   } else {
     uri = encodeURI(uri);
     exec(onSuccess.bind(this, uri, success),
@@ -35,10 +36,11 @@ exports.open = function(uri, success, error, trustAllCertificates) {
  * @param {String} url File URI
  * @param {Function} success Success callback
  * @param {Function} error Failure callback
+ * @param {Function} progress Callback for download progress reporting
  * @param {Boolean} trustAllCertificates Trusts any certificate when the connection is done over HTTPS.
  * @returns {void}
  */
-function downloadAndOpen(url, success, error, trustAllCertificates) {
+function downloadAndOpen(url, success, error, progress, trustAllCertificates) {
   var ft = new FileTransfer();
   var ios = cordova.file.cacheDirectory;
   var ext = cordova.file.externalCacheDirectory;
@@ -49,6 +51,10 @@ function downloadAndOpen(url, success, error, trustAllCertificates) {
   if (typeof trustAllCertificates !== 'boolean') {
     // Defaults to false
     trustAllCertificates = false;
+  }
+
+  if (progress && typeof progress === 'function') {
+    ft.progress = progress;
   }
 
   ft.download(url, path,

--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -54,7 +54,7 @@ function downloadAndOpen(url, success, error, progress, trustAllCertificates) {
   }
 
   if (progress && typeof progress === 'function') {
-    ft.progress = progress;
+    ft.onprogress = progress;
   }
 
   ft.download(url, path,


### PR DESCRIPTION
Simple change to add a progress callback to the filetransfer handler.

Makes it possible to report download progress while waiting for a file to load.